### PR TITLE
fix nginx container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
 
   nginx:
     image: nginx:latest
-    container_name: nginx_geth
+    container_name: nginx
     volumes:
       - ./docker/nginx/geth_nginx.conf:/etc/nginx/nginx.conf:ro
     ports:


### PR DESCRIPTION
reorg tests in  `specs`  override nginx container to start two geth
nodes. `nginx_geth` should be renamed to `nginx` and `nginx` should
be renamed to `nginx_childchain`. Because currently specs override
the wrong container