### PR TITLE
update builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SNAPSHOT ?= SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_20
 BAREBUILD_ENV ?= dev
 ENV_TEST ?= env MIX_ENV=test
 CHILDCHAIN_IMAGE_NAME  ?= "omisego/childchain:latest"
-IMAGE_BUILDER   ?= "omisego/childchain-builder:stable-20200911"
+IMAGE_BUILDER   ?= "omisego/childchain-builder:stable-20200915"
 IMAGE_BUILD_DIR ?= $(PWD)
 ENV_DEV         ?= env MIX_ENV=dev
 ENV_TEST        ?= env MIX_ENV=test


### PR DESCRIPTION
ex_secp256k1 fails to compile on Rust 1.39.0 because of
https://github.com/dalek-cryptography/subtle which works only on Rust
1.41 or higher

new builder image comes with Rust 1.44.0