### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile.childchain
+++ b/Dockerfile.childchain
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 LABEL maintainer="OmiseGO Team <omg@omise.co>"
 LABEL description="Official image for OmiseGO (Childchain) Plasma Network"
@@ -31,7 +31,7 @@ RUN apk add --update --no-cache --virtual .childchain-runtime \
         lksctp-tools
 
 # ex_keccak
-RUN apk add --no-cache rust=1.39.0-r0 cargo=1.39.0-r0
+RUN apk add --no-cache rust=1.44.0-r0 cargo=1.44.0-r0
 
 COPY rootfs /
 


### PR DESCRIPTION
the builder image uses different version of alpine and Rust

That's why the childchain fails with missing nif dependencies