### PR TITLE
fix `deps-childchain` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ deps-childchain:
 	HEX_HTTP_TIMEOUT=120 mix deps.get
 
 deps-prod-childchain:
-	$(ENV_PROD) deps-childchain
+	$(ENV_PROD) make deps-childchain
 
 .PHONY: test test-console test-focus test-console-focus
 


### PR DESCRIPTION
It fails with:
```sh
env: can't execute 'deps-childchain': No such file or directory
make: *** [Makefile:40: deps-prod-childchain] Error 127
make: *** [Makefile:119: docker-childchain-prod] Error 2
```