### PR TITLE
fix: start nonce from 0

### DIFF
--- a/apps/engine/lib/engine/block_formation/prepare_for_submission.ex
+++ b/apps/engine/lib/engine/block_formation/prepare_for_submission.ex
@@ -1,4 +1,4 @@
-defmodule Engine.BlockForming.PrepareForSubmission do
+defmodule Engine.BlockFormation.PrepareForSubmission do
   @moduledoc """
   For blocks in finalizing state:
   - attaches fee transactions
@@ -7,8 +7,8 @@ defmodule Engine.BlockForming.PrepareForSubmission do
   """
   use GenServer
 
-  alias Engine.BlockForming.PrepareForSubmission.AlarmHandler
-  alias Engine.BlockForming.PrepareForSubmission.Core
+  alias Engine.BlockFormation.PrepareForSubmission.AlarmHandler
+  alias Engine.BlockFormation.PrepareForSubmission.Core
   alias Engine.DB.Block
 
   require Logger

--- a/apps/engine/lib/engine/block_formation/prepare_for_submission/alarm_handler.ex
+++ b/apps/engine/lib/engine/block_formation/prepare_for_submission/alarm_handler.ex
@@ -1,4 +1,4 @@
-defmodule Engine.BlockForming.PrepareForSubmission.AlarmHandler do
+defmodule Engine.BlockFormation.PrepareForSubmission.AlarmHandler do
   @moduledoc """
   Listens for :db_connection_lost and cast the alarm back to worker
   """

--- a/apps/engine/lib/engine/block_formation/prepare_for_submission/core.ex
+++ b/apps/engine/lib/engine/block_formation/prepare_for_submission/core.ex
@@ -1,4 +1,4 @@
-defmodule Engine.BlockForming.PrepareForSubmission.Core do
+defmodule Engine.BlockFormation.PrepareForSubmission.Core do
   @moduledoc """
     Preparing block for submission logic
   """

--- a/apps/engine/lib/engine/db/block.ex
+++ b/apps/engine/lib/engine/db/block.ex
@@ -39,7 +39,7 @@ defmodule Engine.DB.Block do
   @type t() :: %{
           hash: binary(),
           state: :forming | :finalizing | :pending_submission | :submitted | :confirmed,
-          nonce: pos_integer(),
+          nonce: non_neg_integer(),
           blknum: pos_integer() | nil,
           tx_hash: binary() | nil,
           formed_at_ethereum_height: pos_integer() | nil,
@@ -63,7 +63,7 @@ defmodule Engine.DB.Block do
     field(:state, Ecto.Atom)
     # nonce = max(nonce) + 1
     field(:nonce, :integer)
-    # blknum = nonce * 1000
+    # blknum = (nonce + 1) * 1000
     field(:blknum, :integer)
     field(:tx_hash, :binary)
     field(:formed_at_ethereum_height, :integer)
@@ -254,11 +254,11 @@ defmodule Engine.DB.Block do
       BlockQuery.select_max_nonce()
       |> repo.one()
       |> case do
-        nil -> 1
+        nil -> 0
         found_nonce -> found_nonce + 1
       end
 
-    blknum = nonce * Configuration.child_block_interval()
+    blknum = (nonce + 1) * Configuration.child_block_interval()
 
     params = %{state: :forming, nonce: nonce, blknum: blknum}
 

--- a/apps/engine/lib/engine/supervisor.ex
+++ b/apps/engine/lib/engine/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Engine.Supervisor do
   """
   use Supervisor
 
-  alias Engine.BlockForming.PrepareForSubmission
+  alias Engine.BlockFormation.PrepareForSubmission
   alias Engine.Configuration
   alias Engine.Ethereum.Authority.Submitter
   alias Engine.Fee.Server, as: FeeServer

--- a/apps/engine/priv/repo/migrations/20200326103841_create_blocks_table.exs
+++ b/apps/engine/priv/repo/migrations/20200326103841_create_blocks_table.exs
@@ -34,7 +34,8 @@ defmodule Engine.Repo.Migrations.CreateBlocksTable do
       constraint(
         :blocks,
         :block_number_nonce,
-        check: "blknum = nonce * 1000"
+        # nonce starts from 0 since there's no transaction when authority account is created
+        check: "blknum = (nonce + 1) * 1000"
       )
     )
 

--- a/apps/engine/test/engine/block_formation/prepare_for_submission/core_test.exs
+++ b/apps/engine/test/engine/block_formation/prepare_for_submission/core_test.exs
@@ -1,7 +1,7 @@
-defmodule Engine.BlockForming.PrepareForSubmission.CoreTest do
+defmodule Engine.BlockFormation.PrepareForSubmission.CoreTest do
   use ExUnit.Case, async: true
 
-  alias Engine.BlockForming.PrepareForSubmission.Core
+  alias Engine.BlockFormation.PrepareForSubmission.Core
 
   describe "should_finalize_block?/3" do
     test "returns true if enough Ethereum blocks were mined since the last finalization" do

--- a/apps/engine/test/engine/block_formation/prepare_for_submission_test.exs
+++ b/apps/engine/test/engine/block_formation/prepare_for_submission_test.exs
@@ -1,7 +1,7 @@
-defmodule Engine.BlockForming.PrepareForSubmissionTest do
+defmodule Engine.BlockFormation.PrepareForSubmissionTest do
   use Engine.DB.DataCase, async: false
 
-  alias Engine.BlockForming.PrepareForSubmission
+  alias Engine.BlockFormation.PrepareForSubmission
   alias Engine.DB.Block
 
   @sleep_time_ms 1_000

--- a/apps/engine/test/engine/db/block/block_changeset_test.exs
+++ b/apps/engine/test/engine/db/block/block_changeset_test.exs
@@ -13,7 +13,7 @@ defmodule Engine.DB.Block.BlockChangesetTest do
       submitted_at_ethereum_height = 2
       gas = 1
       attempts_counter = 1
-      nonce = 1
+      nonce = 0
       blknum = 1_000
       state = Block.state_forming()
 
@@ -49,8 +49,8 @@ defmodule Engine.DB.Block.BlockChangesetTest do
       any_valid? =
         [
           %{blknum: 1_000, state: :forming},
-          %{nonce: 1, state: :forming},
-          %{nonce: 1, blknum: 1_000}
+          %{nonce: 0, state: :forming},
+          %{nonce: 0, blknum: 1_000}
         ]
         |> Enum.map(fn params -> BlockChangeset.new_block_changeset(%Block{}, params) end)
         |> Enum.any?(fn changeset -> changeset.valid? end)

--- a/apps/engine/test/engine/db/transaction_test.exs
+++ b/apps/engine/test/engine/db/transaction_test.exs
@@ -154,9 +154,22 @@ defmodule Engine.DB.TransactionTest do
       assert tx.tx_index == 0
     end
 
-    test "does not insert new block when transaction can be accepted in currently forming block" do
+    test "inserting first transaction in the child-chain creates a block with nonce = 0" do
       tx_bytes = transaction_bytes()
       {:ok, _} = Transaction.insert(tx_bytes)
+
+      nonce = Repo.one(from(b in Block, select: b.nonce))
+      assert nonce == 0
+    end
+
+    test "does not insert new block when transaction can be accepted in currently forming block" do
+      _ = insert(:block)
+
+      tx_bytes1 = transaction_bytes()
+      {:ok, _} = Transaction.insert(tx_bytes1)
+
+      tx_bytes2 = transaction_bytes()
+      {:ok, _} = Transaction.insert(tx_bytes2)
 
       number_of_blocks = Repo.one(from(b in Block, select: count(b.id)))
       assert number_of_blocks == 1

--- a/apps/engine/test/engine/db/transaction_test.exs
+++ b/apps/engine/test/engine/db/transaction_test.exs
@@ -154,7 +154,7 @@ defmodule Engine.DB.TransactionTest do
       assert tx.tx_index == 0
     end
 
-    test "inserting first transaction in the child-chain creates a block with nonce = 0" do
+    test "inserting first transaction in the childchain creates a block with nonce = 0" do
       tx_bytes = transaction_bytes()
       {:ok, _} = Transaction.insert(tx_bytes)
 

--- a/apps/engine/test/support/db/factory.ex
+++ b/apps/engine/test/support/db/factory.ex
@@ -281,10 +281,12 @@ defmodule Engine.DB.Factory do
   end
 
   def block_factory() do
+    nonce = sequence(:block_nonce, fn seq -> seq + 1 end)
+
     %Block{
       hash: :crypto.strong_rand_bytes(32),
-      nonce: sequence(:block_nonce, fn seq -> seq + 1 end),
-      blknum: sequence(:block_blknum, fn seq -> (seq + 1) * 1000 end),
+      nonce: nonce,
+      blknum: (nonce + 1) * 1000,
       state: :forming,
       tx_hash: :crypto.strong_rand_bytes(64),
       formed_at_ethereum_height: 1,


### PR DESCRIPTION
Closes https://github.com/omgnetwork/omg-childchain-v2/issues/167
Changes:
- starts nonce for submit block Ethereum transactions from 0
- require that blknum = (nonce + 1)  * 1000
- rename `Engine.BlockForming...` to `Engine.BlockFormation...`
- fix test for transactions